### PR TITLE
正規表現の修正漏れ　

### DIFF
--- a/server/release/proxy/scripts/controller/outside_socket_io_server_list_manager.js
+++ b/server/release/proxy/scripts/controller/outside_socket_io_server_list_manager.js
@@ -225,6 +225,8 @@
         }
         // The escape sequence '\d' is equivalent to just 'd', so the sequence is not a character class when it is used in a regular expression.
         // The escape sequence '\.' is equivalent to just '.', so the sequence may still represent a meta-character when it is used in a regular expression.
+        // The escape sequence '\s' is equivalent to just 's', so the sequence is not a character class when it is used in a regular expression.
+        // \s*$ -> (\s*$)
         var _regHostnameIPv6 = '^(' +
             '(([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|' +
             '(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|' +
@@ -233,7 +235,7 @@
             '(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|' +
             '(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|' +
             '(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|' +
-            '(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?\s*$';
+            '(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?(\s*$)';
         var _regHostnameIPv6Exp = new RegExp(_regHostnameIPv6);
 
         if(!_regHostnameIPv6Exp.test(hostname)) {

--- a/server/release/proxy/scripts/controller/spf_list_manager.js
+++ b/server/release/proxy/scripts/controller/spf_list_manager.js
@@ -416,6 +416,7 @@
         }
         // The escape sequence '\d' is equivalent to just 'd', so the sequence is not a character class when it is used in a regular expression.
         // The escape sequence '\.' is equivalent to just '.', so the sequence may still represent a meta-character when it is used in a regular expression.
+        // The escape sequence '\s' is equivalent to just 's', so the sequence is not a character class when it is used in a regular expression.
         var _regHostnameIPv6 = '^(' +
             '(([0-9a-f]{1,4}:){7}([0-9a-f]{1,4}|:))|' +
             '(([0-9a-f]{1,4}:){6}(:[0-9a-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|' +
@@ -424,7 +425,7 @@
             '(([0-9a-f]{1,4}:){3}(((:[0-9a-f]{1,4}){1,4})|((:[0-9a-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|' +
             '(([0-9a-f]{1,4}:){2}(((:[0-9a-f]{1,4}){1,5})|((:[0-9a-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|' +
             '(([0-9a-f]{1,4}:){1}(((:[0-9a-f]{1,4}){1,6})|((:[0-9a-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|' +
-            '(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?\s*$';
+            '(:(((:[0-9a-f]{1,4}){1,7})|((:[0-9a-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?(\s*$)';
         var _regHostnameIPv6Exp = new RegExp(_regHostnameIPv6);
 
         if(!_regHostnameIPv6Exp.test(hostname)) {


### PR DESCRIPTION
The escape sequence '\s' is equivalent to just 's', so the sequence is not a character class when it is used in a regular expression.
括弧でくくる